### PR TITLE
35 support all image resolutions

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4,14 +4,24 @@ from segmentmytif.features import extract_features, FeatureType, NUM_FLAIR_CLASS
 
 
 class TestExtractFeatures:
+
+
     def test_extract_identity_features(self):
         input_data = np.array(get_generated_multiband_image())
         result = extract_features(input_data, FeatureType.IDENTITY)
         assert np.array_equal(result, input_data)
-
-    def test_extract_flair_features(self):
-        n_bands = 3
-        input_data = np.array(get_generated_multiband_image(n_bands=n_bands))
+    @pytest.mark.parametrize(["n_bands", "width", "height"],
+                             [
+                                 (3, 1, 1),
+                                 (3, 8, 8),
+                                 (3, 16, 16),  # smallest size that can natively be processed by the model
+                                 (3, 61, 39),  # not divisible by 16 so requires padding in both directions
+                                 (3, 64, 48),  # smallest dimensions, > line above, that don't require padding
+                                 (1, 512, 512),  # size of the model's training data
+                                 (3, 1210, 718),  # not divisible by 16 so requires padding in both directions
+                             ])
+    def test_extract_flair_features(self, n_bands, width, height):
+        input_data = np.array(get_generated_multiband_image(n_bands=n_bands, width=width, height=height))
         result = extract_features(input_data, FeatureType.FLAIR, model_scale=0.125)
         assert np.array_equal(result.shape, [n_bands * NUM_FLAIR_CLASSES] + list(input_data.shape[1:]))
 
@@ -21,8 +31,8 @@ class TestExtractFeatures:
             extract_features(input_data, "UNSUPPORTED_TYPE")
 
 
-def get_generated_multiband_image(n_bands=3):
-    return np.random.random(size=[n_bands, 512, 512])
+def get_generated_multiband_image(n_bands=3, width=512, height=512):
+    return np.random.random(size=[n_bands, width, height])
 
 
 @pytest.mark.parametrize(["model_scale", "file_name"],

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -12,12 +12,12 @@ class TestExtractFeatures:
         assert np.array_equal(result, input_data)
     @pytest.mark.parametrize(["n_bands", "width", "height"],
                              [
-                                 (3, 1, 1),
-                                 (3, 8, 8),
+                                 (3, 1, 1),  # too small to be processed by the model, requires padding
+                                 (3, 8, 8),  # too small to be processed by the model, requires padding
                                  (3, 16, 16),  # smallest size that can natively be processed by the model
                                  (3, 61, 39),  # not divisible by 16 so requires padding in both directions
                                  (3, 64, 48),  # smallest dimensions, > line above, that don't require padding
-                                 (1, 512, 512),  # size of the model's training data
+                                 (1, 512, 512),  # size of the model's training data (easiest case)
                                  (3, 1210, 718),  # not divisible by 16 so requires padding in both directions
                              ])
     def test_extract_flair_features(self, n_bands, width, height):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4,8 +4,6 @@ from segmentmytif.features import extract_features, FeatureType, NUM_FLAIR_CLASS
 
 
 class TestExtractFeatures:
-
-
     def test_extract_identity_features(self):
         input_data = np.array(get_generated_multiband_image())
         result = extract_features(input_data, FeatureType.IDENTITY)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import shutil
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -22,14 +23,22 @@ from .utils import TEST_DATA_FOLDER
                              ("test_image_512x512.tif", "test_image_labels_512x512.tif", FeatureType.FLAIR),
                          ])
 def test_integration(tmpdir, test_image, test_labels, feature_type):
-    input_path = TEST_DATA_FOLDER / test_image
-    labels_path = TEST_DATA_FOLDER / test_labels
+    input_path = copy_file_and_get_new_path(test_image, tmpdir)
+    labels_path = copy_file_and_get_new_path(test_labels, tmpdir)
     predictions_path = Path(tmpdir) / f"{test_image}_predictions_{str(feature_type)}.tif"
 
-    read_input_and_labels_and_save_predictions(input_path, labels_path, predictions_path, feature_type=feature_type,
+    read_input_and_labels_and_save_predictions(input_path, labels_path,
+                                               predictions_path,
+                                               feature_type=feature_type,
                                                model_scale=0.125)  # scale down feature-extraction-model for testing
 
     assert predictions_path.exists()
+
+
+def copy_file_and_get_new_path(test_image, tmpdir):
+    input_path = Path(tmpdir) / test_image
+    shutil.copy(TEST_DATA_FOLDER / test_image, input_path)
+    return input_path
 
 
 @pytest.mark.parametrize("input_path, feature_type, expected_path", [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,4 @@
 import shutil
-import time
-from contextlib import contextmanager
 from pathlib import Path
 
 import dask.array as da
@@ -17,8 +15,7 @@ from .utils import TEST_DATA_FOLDER
 @pytest.mark.parametrize("test_image, test_labels, feature_type",
                          [
                              ("test_image.tif", "test_image_labels.tif", FeatureType.IDENTITY),
-                             pytest.param("test_image.tif", "test_image_labels.tif", FeatureType.FLAIR,
-                                          marks=pytest.mark.xfail(reason="model can only handle 512x512")),
+                             ("test_image.tif", "test_image_labels.tif", FeatureType.FLAIR),
                              ("test_image_512x512.tif", "test_image_labels_512x512.tif", FeatureType.IDENTITY),
                              ("test_image_512x512.tif", "test_image_labels_512x512.tif", FeatureType.FLAIR),
                          ])
@@ -74,3 +71,4 @@ def test_prepare_training_data(array_type):
         input_data = da.from_array(random_data)
 
     prepare_training_data(input_data, labels)
+


### PR DESCRIPTION
1. Added padding to make width and height divisible by 16.
2. Added tests.
3. Added docstrings.
4. Refactored ```extract_flair_features```, splitting it into multiple methods
5. Updated some logger calls as I noticed I needed more info while debugging

Can be tested by 
- running the tests (pytest in root for example)
- running `python .\src\segmentmytif\main.py --input .\tests\test_data\test_image.tif -l .\tests\test_data\test_image_labels.tif -p .\tests\test_data\test_image_out_flair_scale1.tif --feature_type=FLAIR`