### PR TITLE
make upper level logger an optional input

### DIFF
--- a/src/segmentmytif/main.py
+++ b/src/segmentmytif/main.py
@@ -10,6 +10,7 @@ import geopandas as gpd
 import rioxarray
 import dask
 import xarray as xr
+import logging
 
 from segmentmytif.features import get_features, FeatureType, DEFAULT_CHUNK_OVERLAP
 from segmentmytif.logging_config import setup_logger, log_duration, log_array
@@ -29,8 +30,15 @@ def read_input_and_labels_and_save_predictions(
     compute_mode: Literal["normal", "parallel", "safe"] = "normal",
     chunks: dict = None,
     chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+    logger_root: logging.Logger = None,
     **extractor_kwargs,
 ) -> None:
+    # Hijack the global logger if a logger_root is provided
+    # This is designed to be used in QGIS environment
+    if logger_root is not None:
+        global logger
+        logger = logger_root
+
     logger.info("read_input_and_labels_and_save_predictions called with the following arguments:")
     for k, v in locals().items():
         logger.info(f"{k}: {v}")

--- a/src/segmentmytif/main.py
+++ b/src/segmentmytif/main.py
@@ -17,7 +17,9 @@ from segmentmytif.logging_config import setup_logger, log_duration, log_array
 from segmentmytif.utils.io import read_geotiff, save_tiff
 from segmentmytif.utils.geospatial import get_label_array
 
-logger = setup_logger(__name__)
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger = setup_logger(__name__)
 
 
 def read_input_and_labels_and_save_predictions(


### PR DESCRIPTION
Solve #64. This is to facilitate the progress tracking in DroneML plugin. 
To do this, I changed the logger setup in `main.py` to optional.

Should be merged before https://github.com/DroneML/DroneML/pull/25